### PR TITLE
Add support for running plan/apply without locking state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+CHANGELOG
+=========
+
+v0.0.2:
+* Add support for running plan/apply without locking state
+
+v0.0.1:
+* Initial release

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,10 @@ inputs:
     required: false
     description: Whether to run `terraform apply` as last step
     default: 'false'
+  terraform_lock:
+    required: false
+    description: Whehter to (try to) lock the state during plan/apply
+    default: 'false'
 runs:
   using: node12
   main: dist/index.js

--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ inputs:
     default: 'false'
   terraform_lock:
     required: false
-    description: Whehter to (try to) lock the state during plan/apply
+    description: Whether to (try to) lock the state during plan/apply
     default: 'false'
 runs:
   using: node12

--- a/dist/index.js
+++ b/dist/index.js
@@ -42,6 +42,7 @@ function terraform(params) {
 (async () => {
   const terraformDirectory = core.getInput('terraform_directory');
   let terraformDoApply = core.getInput('terraform_do_apply');
+  const terraformLock = core.getInput('terraform_lock');
 
   let tf_version = '<unknown>';
   let tf_init = status_skipped;
@@ -113,7 +114,7 @@ function terraform(params) {
   }
 
   core.startGroup('Run terraform plan');
-  const tfp = terraform('plan -out=terraform.plan');
+  const tfp = terraform('plan -out=terraform.plan -lock=' + terraformLock);
   core.info(tfp.stdout);
   core.endGroup();
   if (tfp.status > 0) {
@@ -126,7 +127,7 @@ function terraform(params) {
 
   core.startGroup('Run terraform apply');
   if (terraformDoApply === 'true') {
-    const tfa = terraform('apply -auto-approve terraform.plan');
+    const tfa = terraform('apply -auto-approve terraform.plan -lock=' + terraformLock);
     core.info(tfa.stdout);
     core.endGroup();
     if (tfa.status > 0) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -50,6 +50,14 @@ function terraform(params) {
   let tf_plan = status_skipped;
   let tf_apply = status_skipped;
 
+  core.startGroup('Sanity checking inputs');
+  if (terraformLock !== 'true' && terraformLock !== 'false') {
+    core.setFailed(`Sanity checks failed. Unknown value for 'terraform_lock': ${terraformLock}`);
+    process.exit(1);
+  }
+  core.info('Good to go!');
+  core.endGroup();
+
   core.startGroup('Configure Google Cloud credentials');
   shell(`printf '%s' '${core.getInput('google_credentials')}' > $GOOGLE_APPLICATION_CREDENTIALS`);
   core.endGroup();

--- a/index.js
+++ b/index.js
@@ -43,6 +43,14 @@ function terraform(params) {
   let tf_plan = status_skipped;
   let tf_apply = status_skipped;
 
+  core.startGroup('Sanity checking inputs');
+  if (terraformLock !== 'true' && terraformLock !== 'false') {
+    core.setFailed(`Sanity checks failed. Unknown value for 'terraform_lock': ${terraformLock}`);
+    process.exit(1);
+  }
+  core.info('Good to go!');
+  core.endGroup();
+
   core.startGroup('Configure Google Cloud credentials');
   shell(`printf '%s' '${core.getInput('google_credentials')}' > $GOOGLE_APPLICATION_CREDENTIALS`);
   core.endGroup();

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ function terraform(params) {
 (async () => {
   const terraformDirectory = core.getInput('terraform_directory');
   let terraformDoApply = core.getInput('terraform_do_apply');
+  const terraformLock = core.getInput('terraform_lock');
 
   let tf_version = '<unknown>';
   let tf_init = status_skipped;
@@ -106,7 +107,7 @@ function terraform(params) {
   }
 
   core.startGroup('Run terraform plan');
-  const tfp = terraform('plan -out=terraform.plan');
+  const tfp = terraform('plan -out=terraform.plan -lock=' + terraformLock);
   core.info(tfp.stdout);
   core.endGroup();
   if (tfp.status > 0) {
@@ -119,7 +120,7 @@ function terraform(params) {
 
   core.startGroup('Run terraform apply');
   if (terraformDoApply === 'true') {
-    const tfa = terraform('apply -auto-approve terraform.plan');
+    const tfa = terraform('apply -auto-approve terraform.plan -lock=' + terraformLock);
     core.info(tfa.stdout);
     core.endGroup();
     if (tfa.status > 0) {


### PR DESCRIPTION
Allows this action to be used using credentials that don't have write access to the state.