### PR TITLE
Add support for limiting the number of concurrent operations during plan/apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 CHANGELOG
 =========
 
+v0.0.3:
+* Add support for limiting the number of concurrent operations during
+  plan/apply. Defaults to upstream's default of 10.
+
 v0.0.2:
-* Add support for running plan/apply without locking state
+* Add support for running plan/apply without locking state. Defaults to no
+  locking.
 
 v0.0.1:
 * Initial release

--- a/action.yaml
+++ b/action.yaml
@@ -17,6 +17,10 @@ inputs:
     required: false
     description: Whether to (try to) lock the state during plan/apply
     default: 'false'
+  terraform_parallelism:
+    required: false
+    description: Limit the number of concurrent operations during plan/apply
+    default: '10'
 runs:
   using: node12
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -127,7 +127,7 @@ function terraform(params) {
   }
 
   core.startGroup('Run terraform plan');
-  const tfp = terraform('plan -out=terraform.plan -lock=' + terraformLock);
+  const tfp = terraform(`plan -out=terraform.plan -lock=${terraformLock} -parallelism=${terraformParallelism}`);
   core.info(tfp.stdout);
   core.endGroup();
   if (tfp.status > 0) {
@@ -140,7 +140,7 @@ function terraform(params) {
 
   core.startGroup('Run terraform apply');
   if (terraformDoApply === 'true') {
-    const tfa = terraform('apply -auto-approve terraform.plan -lock=' + terraformLock);
+    const tfa = terraform(`apply -auto-approve terraform.plan -lock=${terraformLock} -parallelism=${terraformParallelism}`);
     core.info(tfa.stdout);
     core.endGroup();
     if (tfa.status > 0) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -43,6 +43,7 @@ function terraform(params) {
   const terraformDirectory = core.getInput('terraform_directory');
   let terraformDoApply = core.getInput('terraform_do_apply');
   const terraformLock = core.getInput('terraform_lock');
+  const terraformParallelism = core.getInput('terraform_parallelism');
 
   let tf_version = '<unknown>';
   let tf_init = status_skipped;
@@ -53,6 +54,10 @@ function terraform(params) {
   core.startGroup('Sanity checking inputs');
   if (terraformLock !== 'true' && terraformLock !== 'false') {
     core.setFailed(`Sanity checks failed. Unknown value for 'terraform_lock': ${terraformLock}`);
+    process.exit(1);
+  }
+  if (/^\d+$/.test(terraformParellelism)) {
+    core.setFailed(`Sanity checks failed. Non-integer value for 'terraform_parallelism': ${terraformParallelism}`);
     process.exit(1);
   }
   core.info('Good to go!');

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function terraform(params) {
   const terraformDirectory = core.getInput('terraform_directory');
   let terraformDoApply = core.getInput('terraform_do_apply');
   const terraformLock = core.getInput('terraform_lock');
+  const terraformParallelism = core.getInput('terraform_parallelism');
 
   let tf_version = '<unknown>';
   let tf_init = status_skipped;
@@ -46,6 +47,10 @@ function terraform(params) {
   core.startGroup('Sanity checking inputs');
   if (terraformLock !== 'true' && terraformLock !== 'false') {
     core.setFailed(`Sanity checks failed. Unknown value for 'terraform_lock': ${terraformLock}`);
+    process.exit(1);
+  }
+  if (/^\d+$/.test(terraformParellelism)) {
+    core.setFailed(`Sanity checks failed. Non-integer value for 'terraform_parallelism': ${terraformParallelism}`);
     process.exit(1);
   }
   core.info('Good to go!');

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function terraform(params) {
   }
 
   core.startGroup('Run terraform plan');
-  const tfp = terraform('plan -out=terraform.plan -lock=' + terraformLock);
+  const tfp = terraform(`plan -out=terraform.plan -lock=${terraformLock} -parallelism=${terraformParallelism}`);
   core.info(tfp.stdout);
   core.endGroup();
   if (tfp.status > 0) {
@@ -133,7 +133,7 @@ function terraform(params) {
 
   core.startGroup('Run terraform apply');
   if (terraformDoApply === 'true') {
-    const tfa = terraform('apply -auto-approve terraform.plan -lock=' + terraformLock);
+    const tfa = terraform(`apply -auto-approve terraform.plan -lock=${terraformLock} -parallelism=${terraformParallelism}`);
     core.info(tfa.stdout);
     core.endGroup();
     if (tfa.status > 0) {


### PR DESCRIPTION
This allows one to workaround issues with for example tiny CloudSQL instances (too many concurrent connections).