### PR TITLE
Fix destroy planning

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5514,7 +5514,7 @@ async function terraform(args) {
   let terraformDoDestroy = core.getBooleanInput('terraform_do_destroy');
   const terraformLock = core.getBooleanInput('terraform_lock');
   const terraformParallelism = core.getInput('terraform_parallelism');
-  const terraformPlanDestroy = (terraformDoDestroy || core.getBooleanInput('terraform_plan_destroy')) ? '-destroy' : '';
+  const terraformPlanDestroy = (terraformDoDestroy || core.getBooleanInput('terraform_plan_destroy')) ? '-destroy' : [];
   const terraformTargets = core.getMultilineInput('terraform_targets').map((target) => `-target=${target}`);
   const terraformVariables = core.getInput('terraform_variables');
   const terraformWorkspace = core.getInput('terraform_workspace');

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ async function terraform(args) {
   let terraformDoDestroy = core.getBooleanInput('terraform_do_destroy');
   const terraformLock = core.getBooleanInput('terraform_lock');
   const terraformParallelism = core.getInput('terraform_parallelism');
-  const terraformPlanDestroy = (terraformDoDestroy || core.getBooleanInput('terraform_plan_destroy')) ? '-destroy' : '';
+  const terraformPlanDestroy = (terraformDoDestroy || core.getBooleanInput('terraform_plan_destroy')) ? '-destroy' : [];
   const terraformTargets = core.getMultilineInput('terraform_targets').map((target) => `-target=${target}`);
   const terraformVariables = core.getInput('terraform_variables');
   const terraformWorkspace = core.getInput('terraform_workspace');


### PR DESCRIPTION
Prevents:

> Run terraform plan
  /home/runner/terraform plan -lock=false -parallelism=10 -out=terraform.plan 
  ╷
  │ Error: Too many command line arguments
  │ 
  │ To specify a working directory for the plan, use the global -chdir flag.
  ╵
  For more help on using this command, run:
    terraform plan -help
Error: Failed to prepare the terraform plan [err:1]

https://github.com/Pararius/treehouse-dns/runs/5288100181?check_suite_focus=true#step:3:91